### PR TITLE
Add authorization header to file import request

### DIFF
--- a/src/app/admin/manage-products/manage-products.service.ts
+++ b/src/app/admin/manage-products/manage-products.service.ts
@@ -31,11 +31,15 @@ export class ManageProductsService extends ApiService {
 
   private getPreSignedUrl(fileName: string): Observable<{url: string}> {
     const url = this.getUrl('import', 'import');
+    const authorization = localStorage.getItem('authorization_token')!;
 
     return this.http.get<{url: string}>(url, {
       params: {
         name: fileName,
       },
+      headers: {
+        authorization,
+      }
     });
   }
 }


### PR DESCRIPTION
While testing the UI, you need to set a value for `authorization_token` with the following code snippet:

```javascript
localStorage.setItem('authorization_token', 'Q2lsZ2FJc2NhbjpURVNUX1BBU1NXT1JE')
```